### PR TITLE
use strcpy, gcc 4.8 doesn't like snprintf() with an empty format string.

### DIFF
--- a/test/testparser.c
+++ b/test/testparser.c
@@ -426,7 +426,7 @@ int run_tests()
     eprintf("Expected: FAILURE\n");
 
     /* Some examples of bad syntax */
-    snprintf(str, 256, "");
+    strcpy(str, "");
     setup_test('i', 1, 1, src_int, 'f', 1, 3, dest_float);
     result += parse_and_eval(EXPECT_FAILURE);
     eprintf("Expected: FAILURE\n");


### PR DESCRIPTION
Fixes compilation error, `zero-length gnu_printf format string'
